### PR TITLE
print help also if no arguments given

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -118,7 +118,7 @@ gh_toc_get_filename() {
 gh_toc_app() {
     local app_name="gh-md-toc"
 
-    if [ "$1" = '--help' ]; then
+    if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
         echo ""
         echo "Usage:"


### PR DESCRIPTION
A simple addition, script usage will be printed not only if you give ```--help``` but also if you call the script without arguments