### PR TITLE
Help if no args given

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -118,7 +118,7 @@ gh_toc_get_filename() {
 gh_toc_app() {
     local app_name="gh-md-toc"
 
-    if [ "$1" = '--help' ]; then
+    if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
         echo ""
         echo "Usage:"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -87,6 +87,17 @@ load test_helper
     assert_equal "${lines[5]}" "  gh-md-toc --version     Show help"
 }
 
+@test "no arguments" {
+    run $BATS_TEST_DIRNAME/../gh-md-toc
+    assert_success
+    assert_equal "${lines[0]}" "GitHub TOC generator (gh-md-toc): 0.4.0"
+    assert_equal "${lines[1]}" "Usage:"
+    assert_equal "${lines[2]}" "  gh-md-toc src [src]     Create TOC for a README file (url or local path)"
+    assert_equal "${lines[3]}" "  gh-md-toc -             Create TOC for markdown from STDIN"
+    assert_equal "${lines[4]}" "  gh-md-toc --help        Show help"
+    assert_equal "${lines[5]}" "  gh-md-toc --version     Show help"
+}
+
 @test "--version" {
     run $BATS_TEST_DIRNAME/../gh-md-toc --version
     assert_success


### PR DESCRIPTION
simple addition : print usage also if no arguments given, not only if ```--help``` is given
this was the content of my previous pull request, that i just closed to create the current one, when i add a new test to check that we have the same output in this case than if ```--help``` was given.
By the way; some tests unrelated to this were already failing
```
panty@desk:[~/Documents/dev/github-markdown-toc]: bats tests
 ✓ TOC for local README.md
 ✗ TOC for remote README.md
   (from function `assert_equal' in file tests/test_helper.bash, line 7,
    in test file tests/tests.bats, line 32)
     `assert_equal "${lines[2]}"  "  * [sitemap.js](#sitemapjs)"' failed
   expected:   * [sitemap.js](op="mainContentOfPage"><h1><)
   actual:     * [sitemap.js](#sitemapjs)
 ✗ TOC for mixed README.md (remote/local)
   (from function `assert_equal' in file tests/test_helper.bash, line 7,
    in test file tests/tests.bats, line 55)
     `assert_equal "${lines[10]}"  "  * [sitemap.js](https://github.com/ekalinin/sitemap.js/blob/master/README.md#sitemapjs)"' failed
   expected:   * [sitemap.js](https://github.com/ekalinin/sitemap.js/blob/master/README.mdop="mainContentOfPage"><h1><)
   actual:     * [sitemap.js](https://github.com/ekalinin/sitemap.js/blob/master/README.md#sitemapjs)
 ✓ TOC for markdown from stdin
 ✓ --help
 ✓ no arguments
 ✓ --version

```