### PR TITLE
add optional GitHub API token

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -51,9 +51,14 @@ gh_toc_load() {
 # <p>Hello world github/linguist#1 <strong>cool</strong>, and #1!</p>'"
 gh_toc_md2html() {
     local gh_file_md=$1
+    URL=https://api.github.com/markdown/raw
+    TOKEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/token.txt"
+    if [ -f "$TOKEN" ]; then
+        URL="$URL?access_token=$(cat $TOKEN)"
+    fi
     curl -s --user-agent "$gh_user_agent" \
         --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
-        https://api.github.com/markdown/raw
+        $URL
 }
 
 #

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -61,7 +61,7 @@ gh_toc_md2html() {
 #
 gh_is_url() {
     case $1 in
-        https* | http*) 
+        https* | http*)
             echo "yes";;
         *)
             echo "no";;


### PR DESCRIPTION
Not sure if this is the best approach but without the token, requests fail pretty often with a "API rate limit exceeded" error. In that case the script fails to produce any TOC but also fails to report the error.