### PR TITLE
Fix sed syntax for Linux

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -110,20 +110,20 @@ gh_toc(){
         local toc=`gh_toc_md2html "$gh_src" | gh_toc_grab "$gh_src_copy"`
         echo "$toc"
         if [ "$need_replace" = "yes" ]; then
-            local ts="\<\!--ts--\>"
-            local te="\<\!--te--\>"
+            local ts="<\!--ts-->"
+            local te="<\!--te-->"
             local dt=`date +'%F_%H%M%S'`
             local ext=".orig.${dt}"
             local toc_path="${gh_src}.toc.${dt}"
             local toc_footer="<!-- Added by: `whoami`, at: `date --iso-8601='minutes'` -->"
             # http://fahdshariff.blogspot.ru/2012/12/sed-mutli-line-replacement-between-two.html
             # clear old TOC
-            sed -i "${ext}" -e "/${ts}/,/${te}/ {//!d;}" "$gh_src"
+            sed -i${ext} "/${ts}/,/${te}/{//!d}" "$gh_src"
             # create toc file
             echo "${toc}" > "${toc_path}"
             echo -e "\n${toc_footer}\n" >> "$toc_path"
             # insert toc file
-            sed -i "" -e "/${ts}/r ${toc_path}" "$gh_src"
+            sed -i "/${ts}/r ${toc_path}" "$gh_src"
             echo
             echo "!! TOC was added into: '$gh_src'"
             echo "!! Origin version of the file: '${gh_src}${ext}'"


### PR DESCRIPTION
Similar to issues #22 and #24, I ran into some issues while attempting to run this in a modern-ish Linux environment (tested on both Ubuntu 16.04 LTS and CentOS 7.4).  It appears that the issue was with `sed`'s syntax:
```
sed: can't read .orig.2018-02-28_122230: No such file or directory
sed: can't read : No such file or directory
```

I was able to fix this by changing the syntax of `sed` and removing some character escapes.  The included tests successfully pass with this change:

```
$ make test
 ✓ TOC for local README.md
 ✓ TOC for remote README.md
 ✓ TOC for mixed README.md (remote/local)
 ✓ TOC for markdown from stdin
 ✓ --help
 ✓ no arguments
 ✓ --version
 ✓ TOC for non-english chars, #6, #10
 ✓ TOC for text with backquote, #13

9 tests, 0 failures
```

My environment:
```
$ uname -a
Linux PC13261 4.13.0-32-generic #35~16.04.1-Ubuntu SMP Thu Jan 25 10:13:43 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

$ curl --version | head -n 1
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3

$ grep --version | head -n 1
grep (GNU grep) 2.25

$ sed --version | head -n 1
sed (GNU sed) 4.2.2

$ awk -W version
mawk 1.3.3 Nov 1996, Copyright (C) Michael D. Brennan

compiled limits:
max NF             32767
sprintf buffer      2040
```