### PR TITLE
Replace hard coded $app_name

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -169,7 +169,7 @@ gh_toc_get_filename() {
 # Options hendlers
 #
 gh_toc_app() {
-    local app_name="gh-md-toc"
+    local app_name=$(basename $0)
     local need_replace="no"
 
     if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then


### PR DESCRIPTION
I locally renamed the file to `mdtoc` and now the help output doesn't match the actual executable name. This fixes the help output by using the name of the executed file instead of the hard-coded value.