### PR TITLE
fix silent github api rate limited exceeded problem

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -56,13 +56,20 @@ gh_toc_md2html() {
     if [ -f "$TOKEN" ]; then
         URL="$URL?access_token=$(cat $TOKEN)"
     fi
-    curl -s --user-agent "$gh_user_agent" \
+    OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
         --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
-        $URL
+        $URL)"
+
     if [ "$?" != "0" ]; then
         echo "XXNetworkErrorXX"
     fi
+    if [ "$(echo "${OUTPUT}" | awk '/API rate limit exceeded/')" != "" ]; then
+        echo "XXRateLimitXX"
+    else
+        echo "${OUTPUT}"
+    fi
 }
+
 
 #
 # Is passed string url
@@ -119,6 +126,13 @@ gh_toc(){
         if [ "$rawhtml" == "XXNetworkErrorXX" ]; then
              echo "Parsing local markdown file requires access to github API"
              echo "Please make sure curl is installed and check your network connectivity"
+             exit 1
+        fi
+        if [ "$rawhtml" == "XXRateLimitXX" ]; then
+             echo "Parsing local markdown file requires access to github API"
+             echo "Error: You exceeded the hourly limit. See: https://developer.github.com/v3/#rate-limiting"
+             TOKEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/token.txt"
+             echo "or place github auth token here: $TOKEN"
              exit 1
         fi
         local toc=`echo "$rawhtml" | gh_toc_grab "$gh_src_copy"`


### PR DESCRIPTION
- github api rate limited exceeded error is now reported and not silently failing
- plus suggests where to put github auth token

it's not the most elegant solution but it works.

thanks for the script.