### PR TITLE
 Correct BaseName Handling for Spaces in Path

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -201,10 +201,10 @@ gh_toc_get_filename() {
 # Options hendlers
 #
 gh_toc_app() {
-    local app_name=$(basename $0)
     local need_replace="no"
 
     if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
+		local app_name=$(basename "$0")
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
         echo ""
         echo "Usage:"

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -204,7 +204,7 @@ gh_toc_app() {
     local need_replace="no"
 
     if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
-		local app_name=$(basename "$0")
+        local app_name=$(basename "$0")
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
         echo ""
         echo "Usage:"


### PR DESCRIPTION
This corrects "**basename: extra operand ‘VAL1’**" errors as seen below.
Also this moves the basename call to only occur when the help text is displayed.

> $ '/cygdrive/c/Users/myusername/OneDrive - VAL1 VAL2/Utils/github-markdown-toc/gh-md-toc' --help
> /cygdrive/c/Users/myusername/OneDrive - VAL1 VAL2/Utils/github-markdown-toc/gh-md-toc
> **basename: extra operand ‘VAL1’**
> Try 'basename --help' for more information.
> GitHub TOC generator (): 0.5.0
> 
> Usage:
>    [`--`insert] src [src]  Create TOC for a README file (url or local path)
>    `-`                     Create TOC for markdown from STDIN
>    `--`help                Show help
>    `--`version             Show version
