### PR TITLE
Add installation instructions using Basher

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,22 @@ Table of contents
 Installation
 ============
 
-Linux
+Linux (manual installation)
 ```bash
 $ wget https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc
 $ chmod a+x gh-md-toc
 ```
 
-OSX
+macOS (manual installation)
 ```bash
 $ curl https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc -o gh-md-toc
 $ chmod a+x gh-md-toc
+```
+
+Linux or macOS (using [Basher](https://github.com/basherpm/basher))
+```bash
+$ basher install ekalinin/github-markdown-toc
+# `gh-md-toc` will automatically be available in the PATH
 ```
 
 Usage
@@ -153,7 +159,7 @@ Table of Contents
 That's all! Now all you need — is copy/paste result from console into original
 README.md.
 
-If you do not want to copy from console you can add `> YOURFILENAME.md` at the end of the command like `./gh-md-toc https://github.com/ekalinin/envirius/blob/master/README.md > table-of-contents.md` and this will store the table of contents to a file named table-of-contents.md in your current folder. 
+If you do not want to copy from console you can add `> YOURFILENAME.md` at the end of the command like `./gh-md-toc https://github.com/ekalinin/envirius/blob/master/README.md > table-of-contents.md` and this will store the table of contents to a file named table-of-contents.md in your current folder.
 
 And here is a result:
 


### PR DESCRIPTION
This adds installation instructions using [Basher](https://github.com/basherpm/basher). For those who have it installed, this makes it faster to install shell scripts from Git repositories. The directory structure is directly compatble with Basher, so it didn't have to be modified.

This also replaces instances of OS X with macOS (which is the official name as of macOS 10.12).