### PR TITLE
reverse the logic for handling GH_TOC_TOKEN to correct it

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -52,7 +52,7 @@ gh_toc_load() {
 gh_toc_md2html() {
     local gh_file_md=$1
     URL=https://api.github.com/markdown/raw
-    if [ -z "$GH_TOC_TOKEN" ]; then
+    if [ ! -z "$GH_TOC_TOKEN" ]; then
         TOKEN=$GH_TOC_TOKEN
     else
         TOKEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/token.txt"


### PR DESCRIPTION
The check for GH_TOC_TOKEN was using the empty variable when it is
empty, instead of using the default. This change reverses the boolean
test to fix it.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>