### PR TITLE
Add Dockerfile to run it from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian
+
+RUN apt update -y && \
+  apt upgrade -y && \
+  apt install curl -y
+
+WORKDIR app
+
+COPY gh-md-toc .
+
+RUN chmod +x gh-md-toc
+
+ENTRYPOINT ["./gh-md-toc"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -366,3 +366,25 @@ Dependency
   * bats (for unit tests)
 
 Tested on Ubuntu 14.04/14.10 in bash/zsh.
+
+Docker
+==========
+
+* Build
+
+```shell
+docker build -t markdown-toc-generator .
+```
+
+* Run on URL
+
+```shell
+docker run -it markdown-toc-generator https://github.com/ekalinin/envirius/blob/master/README.md
+```
+
+* Run on local (need to share volume with docker)
+
+```shell
+docker run -it -v /data/ekalinin/envirius:/data markdown-toc-generator /data/README.md
+```
+

--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ Docker
 docker build -t markdown-toc-generator .
 ```
 
-* Run on URL
+* Run on an URL
 
 ```shell
 docker run -it markdown-toc-generator https://github.com/ekalinin/envirius/blob/master/README.md
 ```
 
-* Run on local (need to share volume with docker)
+* Run on a local file (need to share volume with docker)
 
 ```shell
 docker run -it -v /data/ekalinin/envirius:/data markdown-toc-generator /data/README.md


### PR DESCRIPTION
I added a simple Dockerfile to run your project from Docker

You can try it out directly by pulling from DockerHub:

```shell
docker run -it vemonet/markdown-toc-generator https://github.com/ekalinin/envirius/blob/master/README.md
```