### PR TITLE
Added Create TOC without backup option --ins-nb

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -96,6 +96,7 @@ gh_toc(){
     local gh_src_copy=$1
     local gh_ttl_docs=$2
     local need_replace=$3
+    local no_backup=$4
 
     if [ "$gh_src" = "" ]; then
         echo "Please, enter URL or local path for a README.md"
@@ -168,9 +169,14 @@ gh_toc(){
                 sed -i "/${ts}/r ${toc_path}" "$gh_src"
             fi
             echo
+            if [ $no_backup = "yes" ]; then
+                rm ${toc_path} ${gh_src}${ext}
+            fi
             echo "!! TOC was added into: '$gh_src'"
-            echo "!! Origin version of the file: '${gh_src}${ext}'"
-            echo "!! TOC added into a separate file: '${toc_path}'"
+            if [ -z $no_backup ]; then
+		echo "!! Origin version of the file: '${gh_src}${ext}'"
+                echo "!! TOC added into a separate file: '${toc_path}'"
+	    fi
             echo
         fi
     fi
@@ -225,6 +231,7 @@ gh_toc_app() {
         echo ""
         echo "Usage:"
         echo "  $app_name [--insert] src [src]  Create TOC for a README file (url or local path)"
+        echo "  $app_name [--no-backup] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
         echo "  $app_name -                     Create TOC for markdown from STDIN"
         echo "  $app_name --help                Show help"
         echo "  $app_name --version             Show version"
@@ -265,10 +272,15 @@ gh_toc_app() {
         shift
     fi
 
+    if [ "$1" = '--no-backup' ]; then
+        need_replace="yes"
+	no_backup="yes"
+        shift
+    fi
     for md in "$@"
     do
         echo ""
-        gh_toc "$md" "$#" "$need_replace"
+        gh_toc "$md" "$#" "$need_replace" "$no_backup"
     done
 
     echo ""

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -174,7 +174,7 @@ gh_toc(){
             fi
             echo "!! TOC was added into: '$gh_src'"
             if [ -z $no_backup ]; then
-		echo "!! Origin version of the file: '${gh_src}${ext}'"
+                echo "!! Origin version of the file: '${gh_src}${ext}'"
                 echo "!! TOC added into a separate file: '${toc_path}'"
 	    fi
             echo
@@ -274,7 +274,7 @@ gh_toc_app() {
 
     if [ "$1" = '--no-backup' ]; then
         need_replace="yes"
-	no_backup="yes"
+        no_backup="yes"
         shift
     fi
     for md in "$@"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -92,9 +92,10 @@ load test_helper
     assert_success
     assert_equal "${lines[1]}" "Usage:"
     assert_equal "${lines[2]}" "  gh-md-toc [--insert] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
-    assert_equal "${lines[4]}" "  gh-md-toc --help                Show help"
-    assert_equal "${lines[5]}" "  gh-md-toc --version             Show version"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
+    assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
+    assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"
 }
 
 @test "no arguments" {
@@ -102,9 +103,10 @@ load test_helper
     assert_success
     assert_equal "${lines[1]}" "Usage:"
     assert_equal "${lines[2]}" "  gh-md-toc [--insert] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
-    assert_equal "${lines[4]}" "  gh-md-toc --help                Show help"
-    assert_equal "${lines[5]}" "  gh-md-toc --version             Show version"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
+    assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
+    assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"
 }
 
 @test "--version" {


### PR DESCRIPTION
First time doing this, hopefully, you consider it for merging.

I tried to do a sed append, however, OSX sed requires a new line. It got really tricky and I abandoned it in favor of just generating the TOC files and deleting them. Dirty but works and keeps your repository clean of backup files.