### PR TITLE
Fixed Authorization token header parameter to curl

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -62,18 +62,12 @@ gh_toc_md2html() {
         fi
     fi
     if [ ! -z "${TOKEN}" ]; then
-        AUTH_TOKEN_STRING="Authorization: token ${TOKEN}"
-        # echo $URL 1>&2
-        OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
-            --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
-            -H "${AUTH_TOKEN_STRING}" \
-            $URL)"
-    else
-        # echo $URL 1>&2
-        OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
-            --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
-            $URL)"
+        AUTHORIZATION=("-H" "Authorization: token ${TOKEN}")
     fi
+    OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
+        --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
+        "${AUTHORIZATION[@]}" \
+        $URL)"
 
     if [ "$?" != "0" ]; then
         echo "XXNetworkErrorXX"

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -25,7 +25,7 @@
 
 gh_toc_version="0.6.2"
 
-gh_user_agent="\"gh-md-toc v$gh_toc_version\""
+gh_user_agent=("--user-agent" "gh-md-toc v${gh_toc_version}")
 
 #
 # Download rendered into html README.md by its url.
@@ -35,9 +35,9 @@ gh_toc_load() {
     local gh_url=$1
 
     if type curl &>/dev/null; then
-        curl --user-agent "$gh_user_agent" -s "$gh_url"
+        curl "${gh_user_agent[@]}" -s "$gh_url"
     elif type wget &>/dev/null; then
-        wget --user-agent="$gh_user_agent" -qO- "$gh_url"
+        wget "${gh_user_agent[@]}" -qO- "$gh_url"
     else
         echo "Please, install 'curl' or 'wget' and try again."
         exit 1
@@ -64,11 +64,10 @@ gh_toc_md2html() {
     if [ ! -z "${TOKEN}" ]; then
         AUTHORIZATION=("-H" "Authorization: token ${TOKEN}")
     fi
-    OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
+    OUTPUT="$(curl -v -s "${gh_user_agent[@]}" \
         --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
         "${AUTHORIZATION[@]}" \
         $URL)"
-
     if [ "$?" != "0" ]; then
         echo "XXNetworkErrorXX"
     fi

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -25,7 +25,7 @@
 
 gh_toc_version="0.6.2"
 
-gh_user_agent="gh-md-toc v$gh_toc_version"
+gh_user_agent="\"gh-md-toc v$gh_toc_version\""
 
 #
 # Download rendered into html README.md by its url.
@@ -62,14 +62,18 @@ gh_toc_md2html() {
         fi
     fi
     if [ ! -z "${TOKEN}" ]; then
-        AUTHORIZATION="--header \"Authorization: token ${TOKEN}\""
+        AUTH_TOKEN_STRING="Authorization: token ${TOKEN}"
+        # echo $URL 1>&2
+        OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
+            --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
+            -H "${AUTH_TOKEN_STRING}" \
+            $URL)"
+    else
+        # echo $URL 1>&2
+        OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
+            --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
+            $URL)"
     fi
-
-    # echo $URL 1>&2
-    OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
-        --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
-        ${AUTHORIZATION} \
-        $URL)"
 
     if [ "$?" != "0" ]; then
         echo "XXNetworkErrorXX"

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -64,7 +64,7 @@ gh_toc_md2html() {
     if [ ! -z "${TOKEN}" ]; then
         AUTHORIZATION=("-H" "Authorization: token ${TOKEN}")
     fi
-    OUTPUT="$(curl -v -s "${gh_user_agent[@]}" \
+    OUTPUT="$(curl -s "${gh_user_agent[@]}" \
         --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
         "${AUTHORIZATION[@]}" \
         $URL)"


### PR DESCRIPTION
This diff ensures that the Authorization header to the curl command is tokenized properly so that the bash command passes the header parameter as a single token instead of three tokens.

This PR fixes https://github.com/ekalinin/github-markdown-toc/issues/90