### PR TITLE
Fix for issue#100 ("+"s in titles)

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -197,6 +197,25 @@ gh_toc(){
 # It's need if TOC is generated for multiple documents.
 #
 gh_toc_grab() {
+    common_awk_script='
+                     modified_href = ""
+                     split(href, chars, "")
+                     for (i=1;i <= length(href); i++) {
+                         c = chars[i]
+                         res = ""
+                         if (c == "+") {
+                             res = " "
+                         } else {
+                             if (c == "%") {
+                                 res = "\\\\x"
+                             } else {
+                                 res = c ""
+                             }
+                         }
+                         modified_href = modified_href res
+                    }
+                    print sprintf("%*s", level*3, " ") "* [" text "](" gh_url  modified_href ")"
+                    '
     if [ `uname -s` == "OS/390" ]; then
         grepcmd="pcregrep -o"
         echoargs=""
@@ -204,8 +223,8 @@ gh_toc_grab() {
                      level = substr($0, length($0), 1)
                      text = substr($0, match($0, /a>.*<\/h/)+2, RLENGTH-5)
                      href = substr($0, match($0, "href=\"([^\"]+)?\"")+6, RLENGTH-7)
-                     print sprintf("%*s", level*3, " ") "* [" text "](" gh_url  href ")"
-                   }'
+                     '"$common_awk_script"'
+                }'
     else
         grepcmd="grep -Eo"
         echoargs="-e"
@@ -213,8 +232,8 @@ gh_toc_grab() {
                      level = substr($0, length($0), 1)
                      text = substr($0, match($0, /a>.*<\/h/)+2, RLENGTH-5)
                      href = substr($0, match($0, "href=\"[^\"]+?\"")+6, RLENGTH-7)
-                     print sprintf("%*s", level*3, " ") "* [" text "](" gh_url  href ")"
-                   }'
+                     '"$common_awk_script"'
+                }'
     fi
     href_regex='href=\"[^\"]+?\"'
 
@@ -239,8 +258,10 @@ gh_toc_grab() {
     # format result line
     #   * $0 - whole string
     #   * last element of each row: "</hN" where N in (1,2,3,...)
-    echo $echoargs "$(awk -v "gh_url=$1" "$awkscript" | sed 'y/+/ /; s/%/\\x/g')"
+    echo $echoargs "$(awk -v "gh_url=$1" "$awkscript")"
 }
+
+        # perl -lpE 's/(\[[^\]]*\]\()(.*?)(\))/my ($pre, $in, $post)=($1, $2, $3) ; $in =~ s{\+}{ }g; $in =~ s{%}{\\x}g; $pre.$in.$post/ems')"
 
 #
 # Returns filename only from full path or url

--- a/tests/test_plussign.md
+++ b/tests/test_plussign.md
@@ -1,0 +1,4 @@
+# C vs C++
+
+Blabla...
+

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -160,3 +160,10 @@ load test_helper
     assert_equal "${lines[5]}"   "      * [The command bar2 is better](#the-command-bar2-is-better)"
     assert_equal "${lines[6]}"   "         * [The command bar3 is the best](#the-command-bar3-is-the-best)"
 }
+
+@test "TOC for text with plus signs, #100" {
+    run $BATS_TEST_DIRNAME/../gh-md-toc tests/test_plussign.md
+    assert_success
+
+    assert_equal "${lines[2]}"   "   * [C vs C++](#c-vs-c)"
+}


### PR DESCRIPTION
See: https://github.com/ekalinin/github-markdown-toc/issues/100

«
Plus signs in the toc's link texts (e.g: in "C++") are overzealously
converted to whitespaces #100
»