### PR TITLE
Bug when using `--insert` without `--no-backup`

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -177,11 +177,11 @@ gh_toc(){
                 sed -i "/${ts}/r ${toc_path}" "$gh_src"
             fi
             echo
-            if [ $no_backup = "yes" ]; then
+            if [ "${no_backup}" = "yes" ]; then
                 rm ${toc_path} ${gh_src}${ext}
             fi
             echo "!! TOC was added into: '$gh_src'"
-            if [ -z $no_backup ]; then
+            if [ -z "${no_backup}" ]; then
                 echo "!! Origin version of the file: '${gh_src}${ext}'"
                 echo "!! TOC added into a separate file: '${toc_path}'"
         fi


### PR DESCRIPTION
When using the `--insert` option to write the TOC back to the analyzed file **without** using the `--no-backup` option, there is a bug because the `no_backup` variable is not set in the environment.

Example:
```
$ gh-md-toc --insert some_file.md 

Table of Contents
=================

   * [generated toc cut off in this example](#generated-toc-cut-off-in-this-example)
Found markers

/home/user/bin/gh-md-toc: line 180: [: =: unary operator expected
!! TOC was added into: 'some_file.md'
!! Origin version of the file: 'some_file.md.orig.2021-01-30_142030'
!! TOC added into a separate file: 'some_file.md.toc.2021-01-30_142030'
```
As you can see above, there is an error message about a unary operator expected on line [line 180](https://github.com/ekalinin/github-markdown-toc/blob/171661836b949aca6c78c691d063bb6bb5246bae/gh-md-toc#L180). This is because the variable is not secured with quotes for the comparison and leads to an error if not set.

This PR fixes this issue (plus secures an other line to prevent further equivalent bugs).