### PR TITLE
utf8 toc generation bug

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -207,7 +207,7 @@ gh_toc_grab() {
                              res = " "
                          } else {
                              if (c == "%") {
-                                 res = "\\\\x"
+                                 res = "\\x"
                              } else {
                                  res = c ""
                              }


### PR DESCRIPTION
Fixes #77
The bug was introduced in #104

You will find a test file here: https://github.com/zeitounator/random-files/blob/main/gh-markdown-toc-%23109-test-file.md#do-you-like-c

**Important note**: the bug was only present when generating the toc from a local file so you will have to save the raw content to a local `.md` file prior to testing. Here is the raw content from the url for reference. I kept the url to make sure there are no drawbacks when calling it directly.
```yaml
# Test file for https://github.com/ekalinin/github-markdown-toc/pull/109
## Make sure bug fixed in #104 is still ok
### Do you like C++
## Make sure bug introduced in #104 is fixed
### Quels sont les prérequis pour installer C++
### Un apperçu des conditions de circulation
### 这是一个例子
```

From what I can see:
* Title text retains the `+` when present as fixed in #104 
* urls for titles with special chars are again generated correctly
* generating directly from url is still ok after this fix

Generating from file before the fix:
```yaml
Table of Contents
=================

   * [Test file for <a href="https://github.com/ekalinin/github-markdown-toc/pull/109">https://github.com/ekalinin/github-markdown-toc/pull/109</a>](#test-file-for-httpsgithubcomekaliningithub-markdown-tocpull109)
      * [Make sure bug fixed in #104 is still ok](#make-sure-bug-fixed-in-104-is-still-ok)
         * [Do you like C++](#do-you-like-c)
      * [Make sure bug introduced in #104 is fixed](#make-sure-bug-introduced-in-104-is-fixed)
         * [Quels sont les prérequis pour installer C++](#quels-sont-les-pr\xC3\xA9requis-pour-installer-c)
         * [Un apperçu des conditions de circulation](#un-apper\xC3\xA7u-des-conditions-de-circulation)
         * [这是一个例子](#\xE8\xBF\x99\xE6\x98\xAF\xE4\xB8\x80\xE4\xB8\xAA\xE4\xBE\x8B\xE5\xAD\x90)
```

Generating from file after the fix. Generating from url unaffected (same toc before and after):
```yaml
Table of Contents
=================

   * [Test file for <a href="https://github.com/ekalinin/github-markdown-toc/pull/109">https://github.com/ekalinin/github-markdown-toc/pull/109</a>](#test-file-for-httpsgithubcomekaliningithub-markdown-tocpull109)
      * [Make sure bug fixed in #104 is still ok](#make-sure-bug-fixed-in-104-is-still-ok)
         * [Do you like C++](#do-you-like-c)
      * [Make sure bug introduced in #104 is fixed](#make-sure-bug-introduced-in-104-is-fixed)
         * [Quels sont les prérequis pour installer C++](#quels-sont-les-prérequis-pour-installer-c)
         * [Un apperçu des conditions de circulation](#un-apperçu-des-conditions-de-circulation)
         * [这是一个例子](#这是一个例子)
```