### PR TITLE
Fix the indentation of the generated TOC

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -218,7 +218,7 @@ gh_toc_grab() {
                          }
                          modified_href = modified_href res
                     }
-                    print sprintf("%*s", level*3, " ") "* [" text "](" gh_url  modified_href ")"
+                    print sprintf("%*s", (level-1)*3, "") "* [" text "](" gh_url  modified_href ")"
                     '
     if [ `uname -s` == "OS/390" ]; then
         grepcmd="pcregrep -o"


### PR DESCRIPTION
At the moment the TOC starts with an indentation : 
```
   * [QuickStart](#quickstart)
      * [Requirements](#requirements)
      * [Setup](#setup)
```
It confuses other tools such as `mkdocs`.

This PR proposes to align the first level of bullets to the left. 
