### PR TITLE
Add flag Find all Markdown files, Ignore ts/te tags, Automatically at the end/head of the file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,130 @@
 *.swp
+# ---> Go
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# ---> JetBrains
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+# ---> VisualStudioCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# ---> macOS
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+token.txt
+

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -106,6 +106,8 @@ gh_toc(){
     local need_replace=$3
     local no_backup=$4
     local no_footer=$5
+    local auto=$6
+    local head=$7
 
     if [ "$gh_src" = "" ]; then
         echo "Please, enter URL or local path for a README.md"
@@ -153,14 +155,38 @@ gh_toc(){
         local toc=`echo "$rawhtml" | gh_toc_grab "$gh_src_copy"`
         echo "$toc"
         if [ "$need_replace" = "yes" ]; then
+            local ts="<\!--ts-->"
+            local te="<\!--te-->"
             if grep -Fxq "<!--ts-->" $gh_src && grep -Fxq "<!--te-->" $gh_src; then
                 echo "Found markers"
             else
-                echo "You don't have <!--ts--> or <!--te--> in your file...exiting"
-                exit 1
+                if [ "$auto" = "yes" ]; then
+                    echo ""
+                    if [ "$head" = "yes" ]; then
+                        echo "!!! TOC will be automatically generated at the $gh_src head."
+                        # insert toc file
+                        if [[ "$(uname)" == "Darwin" ]]; then
+                            sed -i "" "1i\\
+${te}
+              " "$gh_src"
+                            sed -i "" "1i\\
+${ts}
+              " "$gh_src"
+                        else
+                            sed -i "1i\\${te}" "$gh_src"
+                            sed -i "1i\\${ts}" "$gh_src"
+                        fi
+                    else
+                        echo "!!! TOC will be automatically generated at the $gh_src end."
+                        echo "<!--ts-->" >>$gh_src
+                        echo "<!--te-->" >>$gh_src
+                    fi
+
+                else
+                    echo "You don't have <!--ts--> or <!--te--> in your file...exiting"
+                    exit 1
+                fi
             fi
-            local ts="<\!--ts-->"
-            local te="<\!--te-->"
             local dt=`date +'%F_%H%M%S'`
             local ext=".orig.${dt}"
             local toc_path="${gh_src}.toc.${dt}"
@@ -275,11 +301,20 @@ gh_toc_get_filename() {
 }
 
 #
+# Find all Markdown files for non-hidden folders
+#
+gh_all_md_filename() {
+    all_md_filename=""
+    while IFS= read -r -d $'\0'; do
+        all_md_filename=" $all_md_filename $REPLY"
+    done < <(find . -path "*\/\.*" -prune -o -type f -name "*.md" -print0)
+    echo "$all_md_filename"
+}
+
+#
 # Options handlers
 #
 gh_toc_app() {
-    local need_replace="no"
-
     if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
         local app_name=$(basename "$0")
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
@@ -287,6 +322,9 @@ gh_toc_app() {
         echo "Usage:"
         echo "  $app_name [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
         echo "  $app_name [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+        echo "  $app_name --all                 Find all Markdown files for non-hidden folders"
+        echo "  $app_name --auto                Ignore ts/te tags, Automatically at the end/head of the file"
+        echo "  $app_name --head                The TOC is generated in the header of the file, requires --auto"
         echo "  $app_name -                     Create TOC for markdown from STDIN"
         echo "  $app_name --help                Show help"
         echo "  $app_name --version             Show version"
@@ -338,16 +376,42 @@ gh_toc_app() {
         shift
     fi
 
+    if [ "$1" = '--auto' ]; then
+        auto="yes"
+        shift
+    fi
+
+    if [ "$1" = '--head' ]; then
+        head="yes"
+        shift
+    fi
+
     if [ "$1" = '--hide-footer' ]; then
         need_replace="yes"
         no_footer="yes"
         shift
     fi
 
-    for md in "$@"
-    do
+    if [ "$1" = '--all' ]; then
+        gh_toc_app `gh_all_md_filename`
+        return
+    fi
+
+    if [ "$need_replace" != "yes" ]; then
+        need_replace="no"
+    fi
+
+    base_path=$(pwd)
+    for md in "$@"; do
         echo ""
-        gh_toc "$md" "$#" "$need_replace" "$no_backup" "$no_footer"
+        dir_path=${md%/*}
+        md=${md##*/}
+        if [ ! "$dir_path" == "$md" ]; then
+            cd "$dir_path" || exit
+        fi
+
+        gh_toc "$md" "$#" "$need_replace" "$no_backup" "$no_footer" "$auto" "$head"
+        cd "$base_path" || exit
     done
 
     echo ""

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -95,22 +95,28 @@ load test_helper
     run $BATS_TEST_DIRNAME/../gh-md-toc --help
     assert_success
     assert_equal "${lines[1]}" "Usage:"
-    assert_equal "${lines[2]}" "  gh-md-toc [--insert] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
-    assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
-    assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
-    assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"
+    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[4]}" "  gh-md-toc --all                 Find all Markdown files for non-hidden folders"
+    assert_equal "${lines[5]}" "  gh-md-toc --auto                Ignore ts/te tags, Automatically at the end/head of the file"
+    assert_equal "${lines[6]}" "  gh-md-toc --head                The TOC is generated in the header of the file, requires --auto"
+    assert_equal "${lines[7]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
+    assert_equal "${lines[8]}" "  gh-md-toc --help                Show help"
+    assert_equal "${lines[9]}" "  gh-md-toc --version             Show version"
 }
 
 @test "no arguments" {
     run $BATS_TEST_DIRNAME/../gh-md-toc
     assert_success
     assert_equal "${lines[1]}" "Usage:"
-    assert_equal "${lines[2]}" "  gh-md-toc [--insert] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
-    assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
-    assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
-    assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"
+    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[4]}" "  gh-md-toc --all                 Find all Markdown files for non-hidden folders"
+    assert_equal "${lines[5]}" "  gh-md-toc --auto                Ignore ts/te tags, Automatically at the end/head of the file"
+    assert_equal "${lines[6]}" "  gh-md-toc --head                The TOC is generated in the header of the file, requires --auto"
+    assert_equal "${lines[7]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
+    assert_equal "${lines[8]}" "  gh-md-toc --help                Show help"
+    assert_equal "${lines[9]}" "  gh-md-toc --version             Show version"
 }
 
 @test "--version" {
@@ -166,4 +172,35 @@ load test_helper
     assert_success
 
     assert_equal "${lines[2]}"   "   * [C vs C++](#c-vs-c)"
+}
+
+@test "TOC for local all" {
+	run $BATS_TEST_DIRNAME/../gh-md-toc --all
+	assert_success
+
+	assert_equal "${lines[0]}" "   * [The command foo1](test_backquote.md#the-command-foo1)"
+	assert_equal "${lines[1]}" "      * [The command foo2 is better](test_backquote.md#the-command-foo2-is-better)"
+	assert_equal "${lines[2]}" "   * [The command bar1](test_backquote.md#the-command-bar1)"
+	assert_equal "${lines[3]}" "      * [The command bar2 is better](test_backquote.md#the-command-bar2-is-better)"
+	assert_equal "${lines[4]}" "         * [The command bar3 is the best](test_backquote.md#the-command-bar3-is-the-best)"
+
+	assert_equal "${lines[5]}" "   * [C vs C++](test_plussign.md#c-vs-c)"
+
+	assert_equal "${lines[6]}" "   * [gh-md-toc](README.md#gh-md-toc)"
+	assert_equal "${lines[7]}" "   * [Table of contents](README.md#table-of-contents)"
+	assert_equal "${lines[8]}" "   * [Installation](README.md#installation)"
+	assert_equal "${lines[9]}" "   * [Usage](README.md#usage)"
+	assert_equal "${lines[10]}" "      * [STDIN](README.md#stdin)"
+	assert_equal "${lines[11]}" "      * [Local files](README.md#local-files)"
+	assert_equal "${lines[12]}" "      * [Remote files](README.md#remote-files)"
+	assert_equal "${lines[13]}" "      * [Multiple files](README.md#multiple-files)"
+	assert_equal "${lines[14]}" "      * [Combo](README.md#combo)"
+	assert_equal "${lines[15]}" "      * [Auto insert and update TOC](README.md#auto-insert-and-update-toc)"
+	assert_equal "${lines[16]}" "      * [GitHub token](README.md#github-token)"
+	assert_equal "${lines[17]}" "      * [TOC generation with Github Actions](README.md#toc-generation-with-github-actions)"
+	assert_equal "${lines[18]}" "   * [Tests](README.md#tests)"
+	assert_equal "${lines[19]}" "   * [Dependency](README.md#dependency)"
+	assert_equal "${lines[20]}" "   * [Docker](README.md#docker)"
+	assert_equal "${lines[21]}" "      * [Local](README.md#local)"
+	assert_equal "${lines[22]}" "      * [Public](README.md#public)"
 }


### PR DESCRIPTION
--all Find all Markdown files for non-hidden folders
--auto Ignore ts/te tags, Automatically at the end/head of the file
--head The TOC is generated in the header of the file, requires --auto


just pr and can close https://github.com/ekalinin/github-markdown-toc/pull/115