### PR TITLE
Skip headers if end marker is present

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -51,6 +51,8 @@ gh_toc_load() {
 # <p>Hello world github/linguist#1 <strong>cool</strong>, and #1!</p>'"
 gh_toc_md2html() {
     local gh_file_md=$1
+    local skip_header=$2
+
     URL=https://api.github.com/markdown/raw
 
     if [ ! -z "$GH_TOC_TOKEN" ]; then
@@ -66,11 +68,12 @@ gh_toc_md2html() {
     fi
 
     local gh_tmp_file_md=$gh_file_md
-    if grep -Fxq "<!--te-->" $gh_src; then
-      # cut everything before the toc
-      gh_tmp_file_md=$gh_file_md~~
-      sed '1,/<!--te-->/d' $gh_file_md > $gh_tmp_file_md
-
+    if [ "$skip_header" = "yes" ]; then
+        if grep -Fxq "<!--te-->" $gh_src; then
+          # cut everything before the toc
+          gh_tmp_file_md=$gh_file_md~~
+          sed '1,/<!--te-->/d' $gh_file_md > $gh_tmp_file_md
+        fi
     fi
 
     # echo $URL 1>&2
@@ -80,6 +83,7 @@ gh_toc_md2html() {
         -H "Content-Type:text/plain" \
         -H "$AUTHORIZATION" \
         "$URL")
+
     rm -f $gh_file_md~~
 
     if [ "$?" != "0" ]; then
@@ -115,6 +119,7 @@ gh_toc(){
     local need_replace=$3
     local no_backup=$4
     local no_footer=$5
+    local skip_header=$6
 
     if [ "$gh_src" = "" ]; then
         echo "Please, enter URL or local path for a README.md"
@@ -146,7 +151,7 @@ gh_toc(){
             echo
         fi
     else
-        local rawhtml=$(gh_toc_md2html "$gh_src")
+        local rawhtml=$(gh_toc_md2html "$gh_src" "$skip_header")
         if [ "$rawhtml" == "XXNetworkErrorXX" ]; then
              echo "Parsing local markdown file requires access to github API"
              echo "Please make sure curl is installed and check your network connectivity"
@@ -256,16 +261,16 @@ gh_toc_grab() {
     #        </h1>
     #   became: The command <code>foo1</code></h1>
     sed -e ':a' -e 'N' -e '$!ba' -e 's/\n<\/h/<\/h/g' |
-    
+
     # find strings that corresponds to template
     $grepcmd '<a.*id="user-content-[^"]*".*</h[1-6]' |
-    
+
     # remove code tags
     sed 's/<code>//g' | sed 's/<\/code>//g' |
 
     # remove g-emoji
     sed 's/<g-emoji[^>]*[^<]*<\/g-emoji> //g' |
-    
+
     # now all rows are like:
     #   <a id="user-content-..." href="..."><span ...></span></a> ... </h1
     # format result line
@@ -294,8 +299,8 @@ gh_toc_app() {
         echo "GitHub TOC generator ($app_name): $gh_toc_version"
         echo ""
         echo "Usage:"
-        echo "  $app_name [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
-        echo "  $app_name [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+        echo "  $app_name [--insert] [--hide-footer] [--skip-header] src [src]  Create TOC for a README file (url or local path)"
+        echo "  $app_name [--no-backup] [--hide-footer] [--skip-header] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
         echo "  $app_name -                     Create TOC for markdown from STDIN"
         echo "  $app_name --help                Show help"
         echo "  $app_name --version             Show version"
@@ -353,10 +358,16 @@ gh_toc_app() {
         shift
     fi
 
+    if [ "$1" = '--skip-header' ]; then
+        skip_header="yes"
+        shift
+    fi
+
+
     for md in "$@"
     do
         echo ""
-        gh_toc "$md" "$#" "$need_replace" "$no_backup" "$no_footer"
+        gh_toc "$md" "$#" "$need_replace" "$no_backup" "$no_footer" "$skip_header"
     done
 
     echo ""

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -65,13 +65,22 @@ gh_toc_md2html() {
         AUTHORIZATION="Authorization: token ${TOKEN}"
     fi
 
+    local gh_tmp_file_md=$gh_file_md
+    if grep -Fxq "<!--te-->" $gh_src; then
+      # cut everything before the toc
+      gh_tmp_file_md=$gh_file_md~~
+      sed '1,/<!--te-->/d' $gh_file_md > $gh_tmp_file_md
+
+    fi
+
     # echo $URL 1>&2
     OUTPUT=$(curl -s \
         --user-agent "$gh_user_agent" \
-        --data-binary @"$gh_file_md" \
+        --data-binary @"$gh_tmp_file_md" \
         -H "Content-Type:text/plain" \
         -H "$AUTHORIZATION" \
         "$URL")
+    rm -f $gh_file_md~~
 
     if [ "$?" != "0" ]; then
         echo "XXNetworkErrorXX"

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -304,7 +304,7 @@ gh_toc_app() {
         echo ""
         echo "Usage:"
         echo "  $app_name [--insert] [--hide-footer] [--skip-header] [--indent #spaces] src [src]  Create TOC for a README file (url or local path)"
-        echo "  $app_name [--no-backup] [--hide-footer] [--skip-header]  [--indent #spaces] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+        echo "  $app_name [--no-backup] [--hide-footer] [--skip-header] [--indent #spaces] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
         echo "  $app_name -                     Create TOC for markdown from STDIN"
         echo "  $app_name --help                Show help"
         echo "  $app_name --version             Show version"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -98,8 +98,8 @@ load test_helper
     run $BATS_TEST_DIRNAME/../gh-md-toc --help
     assert_success
     assert_equal "${lines[1]}" "Usage:"
-    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] [--skip-header] src [src]  Create TOC for a README file (url or local path)"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] [--skip-header] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
     assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
     assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
     assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"
@@ -109,8 +109,8 @@ load test_helper
     run $BATS_TEST_DIRNAME/../gh-md-toc
     assert_success
     assert_equal "${lines[1]}" "Usage:"
-    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] src [src]  Create TOC for a README file (url or local path)"
-    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
+    assert_equal "${lines[2]}" "  gh-md-toc [--insert] [--hide-footer] [--skip-header] src [src]  Create TOC for a README file (url or local path)"
+    assert_equal "${lines[3]}" "  gh-md-toc [--no-backup] [--hide-footer] [--skip-header] src [src]  Create TOC without backup, requires <!--ts--> / <!--te--> placeholders"
     assert_equal "${lines[4]}" "  gh-md-toc -                     Create TOC for markdown from STDIN"
     assert_equal "${lines[5]}" "  gh-md-toc --help                Show help"
     assert_equal "${lines[6]}" "  gh-md-toc --version             Show version"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -30,6 +30,30 @@ load test_helper
 
 }
 
+@test "TOC for local README.md with skip headers" {
+    run $BATS_TEST_DIRNAME/../gh-md-toc --skip-header README.md
+    assert_success
+
+    assert_equal "${lines[0]}"  "Table of Contents"
+    assert_equal "${lines[1]}"  "================="
+    assert_equal "${lines[2]}"  "* [Installation](#installation)"
+    assert_equal "${lines[3]}"  "* [Usage](#usage)"
+    assert_equal "${lines[4]}"  "   * [STDIN](#stdin)"
+    assert_equal "${lines[5]}"  "   * [Local files](#local-files)"
+    assert_equal "${lines[6]}"  "   * [Remote files](#remote-files)"
+    assert_equal "${lines[7]}"  "   * [Multiple files](#multiple-files)"
+    assert_equal "${lines[8]}" "   * [Combo](#combo)"
+    assert_equal "${lines[9]}" "   * [Auto insert and update TOC](#auto-insert-and-update-toc)"
+    assert_equal "${lines[10]}" "   * [GitHub token](#github-token)"
+    assert_equal "${lines[11]}" "   * [TOC generation with Github Actions](#toc-generation-with-github-actions)"
+    assert_equal "${lines[12]}" "* [Tests](#tests)"
+    assert_equal "${lines[13]}" "* [Dependency](#dependency)"
+    assert_equal "${lines[14]}" "* [Docker](#docker)"
+    assert_equal "${lines[15]}" "   * [Local](#local)"
+    assert_equal "${lines[16]}" "   * [Public](#public)"
+    assert_equal "${lines[17]}" "Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)"
+
+}
 @test "TOC for remote README.md" {
     run $BATS_TEST_DIRNAME/../gh-md-toc https://github.com/ekalinin/sitemap.js/blob/6bc3eb12c898c1037a35a11b2eb24ababdeb3580/README.md
     assert_success

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -51,7 +51,7 @@ load test_helper
     assert_equal "${lines[14]}" "* [Docker](#docker)"
     assert_equal "${lines[15]}" "   * [Local](#local)"
     assert_equal "${lines[16]}" "   * [Public](#public)"
-    assert_equal "${lines[17]}" "Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)"
+    assert_equal "${lines[17]}" "<!-- Created by https://github.com/ekalinin/github-markdown-toc -->"
 
 }
 @test "TOC for remote README.md" {


### PR DESCRIPTION
This PR is trying to resolve #125. In case the end marker <!--te--> is present all lines before this marker are removed for further processing.  