### PR TITLE
Fix for  #128: Documentation enhancement for Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,8 @@ jobs:
       - run: |
           curl https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc -o gh-md-toc
           chmod a+x gh-md-toc
-          ./gh-md-toc --insert --no-backup foo.md
+          ./gh-md-toc --insert --no-backup --hide-footer foo.md
+          rm gh-md-toc
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto update markdown TOC


### PR DESCRIPTION
Hi, 

this PR enhances the [example](https://github.com/ekalinin/github-markdown-toc#toc-generation-with-github-actions) for use of this project with Github Actions. The problems I faced when I copy and pasted the example into my Github Action are described in issue #128.

Adding the `--hide-footer` flag makes sure that no unnecessary auto-commit is generated by the Gitub Action. For example, if you were to change the content of `foo.md`, but would leave the  structure of its headlines intact, there is no need to generate a new TOC. `gh-md-toc` adds a `footer` comment to your TOC that reads something like `<!-- Created by <user> at <datetime> -->`. This changes every time `gh-md-toc` is executed at a different `datetime`. Hiding the footer makes running `gh-md-toc` idempotent, if the headers in `foo.md` do not change. This removes auto-commits by the Github Action even when the TOC does not change.

Adding the `rm gh-md-toc` line to the action removes the `gh-md-toc` script from the repository again, so it won't be added to the repo by the auto-commit of the Github Action.