### PR TITLE
portable sed commands

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -175,7 +175,7 @@ gh_toc(){
             fi
 
             # insert toc file
-            if [[ "`uname`" == "Darwin" ]]; then
+            if ! sed --version > /dev/null 2>&1; then
                 sed -i "" "/${ts}/r ${toc_path}" "$gh_src"
             else
                 sed -i "/${ts}/r ${toc_path}" "$gh_src"


### PR DESCRIPTION
The original sed variant detection worked by checking the operating system type- if the OS is darwin (ie, OSX) it uses the BSD sed, otherwise the GNU sed.

This change instead uses "duck typing" to identify the variant. It runs `sed --version` to detect whether the linux or bsd version is running. On the OSX/BSD version the `sed --version` command fails, but on the gnu version it succeeds. 

This allows the script to work in two cases where it otherwise fails-
1. For people (like me) who install the updated gnu versions of everything on their OSX machines.
2. On other BSD style systems.