### PR TITLE
Fix #131: --indent argument makes the script crashed

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -349,7 +349,7 @@ gh_toc_app() {
 
     if [ "$1" = '--indent' ]; then
         indent="$2"
-        shift
+        shift 2
     fi
 
     if [ "$1" = "-" ]; then


### PR DESCRIPTION
Fix [#131](https://github.com/ekalinin/github-markdown-toc/issues/131).
Because `--indent` is followed by `<NUM>`, we need `shift 2` to remove two arguments when parsing it.