### PR TITLE
fix: shift 2 when consuming 2 arguments

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -349,7 +349,7 @@ gh_toc_app() {
 
     if [ "$1" = '--indent' ]; then
         indent="$2"
-        shift
+        shift 2
     fi
 
     if [ "$1" = "-" ]; then


### PR DESCRIPTION
When using `--indent` we should shift 2 arguments instead of 1 to avoid the error as shown below.

```terminal
$ gh-md-toc --indent 2 --no-backup README.md



rm: illegal option -- -
usage: rm [-f | -i] [-dIPRrvWx] file ...
       unlink [--] file
Parsing local markdown file requires access to github API
Please make sure curl is installed and check your network connectivity
```