### PR TITLE
Update CLI to handle multiple arguments

### DIFF
--- a/gh-md-toc
+++ b/gh-md-toc
@@ -337,63 +337,67 @@ gh_toc_app() {
     local need_replace="no"
     local indent=3
 
-    if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
+    if [ $# -eq 0 ] ; then
         show_help
         return
     fi
 
-    if [ "$1" = '--version' ]; then
-        show_version
-        return
-    fi
-
-    if [ "$1" = '--indent' ]; then
-        indent="$2"
-        shift
-    fi
-
-    if [ "$1" = "-" ]; then
-        if [ -z "$TMPDIR" ]; then
-            TMPDIR="/tmp"
-        elif [ -n "$TMPDIR" -a ! -d "$TMPDIR" ]; then
-            mkdir -p "$TMPDIR"
-        fi
-        local gh_tmp_md
-        if [ `uname -s` == "OS/390" ]; then
-            local timestamp=$(date +%m%d%Y%H%M%S)
-            gh_tmp_md="$TMPDIR/tmp.$timestamp"
-        else
-            gh_tmp_md=$(mktemp $TMPDIR/tmp.XXXXXX)
-        fi
-        while read input; do
-            echo "$input" >> "$gh_tmp_md"
-        done
-        gh_toc_md2html "$gh_tmp_md" | gh_toc_grab "" "$indent"
-        return
-    fi
-
-    if [ "$1" = '--insert' ]; then
-        need_replace="yes"
-        shift
-    fi
-
-    if [ "$1" = '--no-backup' ]; then
-        need_replace="yes"
-        no_backup="yes"
-        shift
-    fi
-
-    if [ "$1" = '--hide-footer' ]; then
-        need_replace="yes"
-        no_footer="yes"
-        shift
-    fi
-
-    if [ "$1" = '--skip-header' ]; then
-        skip_header="yes"
-        shift
-    fi
-
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            --help)
+                show_help
+                return
+                ;;
+            --version)
+                show_version
+                return
+                ;;
+            --indent)
+                indent="$2"
+                shift 2
+                ;;
+            -)
+                if [ -z "$TMPDIR" ]; then
+                    TMPDIR="/tmp"
+                elif [ -n "$TMPDIR" -a ! -d "$TMPDIR" ]; then
+                    mkdir -p "$TMPDIR"
+                fi
+                local gh_tmp_md
+                if [ `uname -s` == "OS/390" ]; then
+                    local timestamp=$(date +%m%d%Y%H%M%S)
+                    gh_tmp_md="$TMPDIR/tmp.$timestamp"
+                else
+                    gh_tmp_md=$(mktemp $TMPDIR/tmp.XXXXXX)
+                fi
+                while read input; do
+                    echo "$input" >> "$gh_tmp_md"
+                done
+                gh_toc_md2html "$gh_tmp_md" | gh_toc_grab "" "$indent"
+                return
+                ;;
+            --insert)
+                need_replace="yes"
+                shift
+                ;;
+            --no-backup)
+                need_replace="yes"
+                no_backup="yes"
+                shift
+                ;;
+            --hide-footer)
+                need_replace="yes"
+                no_footer="yes"
+                shift
+                ;;
+            --skip-header)
+                skip_header="yes"
+                shift
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
 
     for md in "$@"
     do


### PR DESCRIPTION
If specifying multiple arguments to the script, only the first argument is properly consumed, the others are treated as input files and generate errors such as:
```
./gh-md-toc --insert --indent 2 NOTES.md > toc.md
rm: unrecognized option '--indent~~'
Try 'rm --help' for more information.
```

The present CLI handler only looks at the first argument $1 before proceeding. This updates the handler to process all defined CLI arguments until it sees an argument that doesn't match, at which point it treats the rest as input files. This also includes the fix for the --indent argument that was outlined here: https://github.com/ekalinin/github-markdown-toc/pull/132

Existing tests passed when run locally:
```
make test
 ✓ TOC for local README.md
 ✓ TOC for local README.md with skip headers
 ✓ TOC for remote README.md
 ✓ TOC for mixed README.md (remote/local)
 ✓ TOC for markdown from stdin
 ✓ --help
 ✓ no arguments
 ✓ --version
 ✓ TOC for non-english chars, #6, #10
 ✓ TOC for text with backquote, #13
 ✓ TOC for text with plus signs, #100

11 tests, 0 failures
```