### PR TITLE
Don't leak GH token in `token.txt` by adding it to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+token.txt


### PR DESCRIPTION
When writing #154 I had to add my GitHub PAT to the repo in `token.txt` to avoid rate limitations when querying the GitHub API. `token.txt` is currently not ignored in version control, which can easily lead to leaked access tokens. To avoid this, `token.txt` should by added to `.gitignore`, which I have done in this PR. I did not write an extra issue for such a small change, hope that is okay.